### PR TITLE
Add set meta_box_cb to false option

### DIFF
--- a/inc/class-mb-custom-taxonomy-edit.php
+++ b/inc/class-mb-custom-taxonomy-edit.php
@@ -216,6 +216,12 @@ class MB_Custom_Taxonomy_Edit {
 				'std'  => 1,
 				'desc' => __( 'Whether taxonomy is available for selection in navigation menus.', 'mb-custom-taxonomy' ),
 			),
+                    	array(
+				'name' => __( 'Show in editor page?', 'mb-custom-taxonomy' ),
+				'id'   => $args_prefix . 'meta_box_cb',
+				'type' => 'checkbox',
+				'desc' => __( 'Whether to show the on the editor page.', 'mb-custom-taxonomy' ),
+			),
 			array(
 				'name' => __( 'Show tag cloud?', 'mb-custom-taxonomy' ),
 				'id'   => $args_prefix . 'show_tagcloud',
@@ -266,7 +272,7 @@ class MB_Custom_Taxonomy_Edit {
 				'id'   => $args_prefix . 'sort',
 				'type' => 'checkbox',
 				'desc' => __( 'Whether this taxonomy should remember the order in which terms are added to objects.', 'mb-custom-taxonomy' ),
-			),
+			)
 		);
 
 		// Basic settings.

--- a/inc/class-mb-custom-taxonomy-register.php
+++ b/inc/class-mb-custom-taxonomy-register.php
@@ -63,6 +63,9 @@ class MB_Custom_Taxonomy_Register {
 		// Get all registered custom taxonomies.
 		$taxonomies = $this->get_taxonomies();
 		foreach ( $taxonomies as $taxonomy => $args ) {
+                        if (false !== $args['meta_box_cb']) {
+                            unset($args['meta_box_cb']);
+                        }
 			register_taxonomy( $taxonomy, $args['post_types'], $args );
 		}
 	}


### PR DESCRIPTION
Sometimes the user may want to hide the taxonomy on the editor page.  and using Meta Box plugin to manage the taxonomy, because Meta Box plugin gives the developer more control options, e.g: select box, checkbox, dropdown..etc.  